### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Despite its small size, the pocket arcade fight pad packs a lot of functionality
 # Setup
 To get started with your Waveshare RP2040, download the pre-built firmware from this [link](https://github.com/OpenStickCommunity/GP2040-CE/releases). Once downloaded, flash the MCU.
 
-The GP2040 features a web-based configuration application that can be accessed by holding down K1 when plugging your controller into a PC. To begin configuration, simply visit http://192.168.7.1. Under the Data Backup and Restoration section, upload the StressConfig.gp2040 file.
+The GP2040 features a web-based configuration application that can be accessed by holding down K1 when plugging your controller into a PC. To begin configuration, simply visit http://192.168.7.1.
 
 After uploading, you can access the web configuration by clicking the Start button. Your Stress Pad should now be ready to use.
 


### PR DESCRIPTION
Uploading `StressConfig.gp2040` is not necessary and overrides the default mapping in firmware.

I had issues configuring my Stress Pad because the configuration in `StressConfig.gp2040` contains non-standard configuration settings as well as having the player number light enabled causing the k1 button to flash seemingly randomly